### PR TITLE
Add missing file to build.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include gitgeo/world_cities.csv
 include gitgeo/geographies_list.csv
+include gitgeo/country_codes.csv

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fd:
 
 setup(
     name="gitgeo",
-    version="1.0.0",
+    version="1.0.1",
     description="Discover the geography of open-source software. Explore the geographic locations of software developers associated with a GitHub repository or a Python (PyPI) package.",
     long_description=open("README.rst").read(),
     keywords="open_source github",


### PR DESCRIPTION
Addresses issue #59 

To reproduce 

```
pip uninstall gitgeo
python setup.py sdist bdist_wheel
pip install dist/gitgeo-1.0.1-py3-none-any.whl 
```

Now

```gitgeo --help```

should work
