### PR TITLE
Update a test given changing package data

### DIFF
--- a/tests/test_gitgeo.py
+++ b/tests/test_gitgeo.py
@@ -391,8 +391,8 @@ def test_print_by_contributor_package(capsys):
         CStephenson970 | None | None
         renovate-bot | None | None
         lilchurro | None | None
-        jspeed-meyers * | None | None
         rashley-iqt | None | None
+        jspeed-meyers * | None | None
         pyup-bot | None | None
         alshaboti | Wellington, New Zealand | New Zealand
         jseparovic | Mountain View, CA | United States


### PR DESCRIPTION
Some of the tests are flaky because they rely on examining data that changes. In this case, because one contributor's number of commit contributions now exceeds another, the test "fails." Some test refactoring is likely in order, in the long run.